### PR TITLE
Update install_mac.sh

### DIFF
--- a/BoardDefinition/install_mac.sh
+++ b/BoardDefinition/install_mac.sh
@@ -1,1 +1,9 @@
-cp esp32-s3-devkitc-1-myboard.json /Users/mikewarriner/.platformio/platforms/espressif32/boards/esp32-s3-devkitc-1-myboard.json
+#!/bin/bash
+
+DESTINATION="$HOME/.platformio/platforms/espressif32/boards/esp32-s3-devkitc-1-myboard.json"
+
+mkdir -p "$(dirname "$DESTINATION")"
+
+cp esp32-s3-devkitc-1-myboard.json "$DESTINATION"
+
+echo "File copied to $DESTINATION"


### PR DESCRIPTION
Updated to remove hard coded reference to your user folder and replace it with currently logged in home folder and also handle creation of destination folders if they do not exist.